### PR TITLE
🐛 Fix book UI Link overlay

### DIFF
--- a/src/components/Book/CategoryView.tsx
+++ b/src/components/Book/CategoryView.tsx
@@ -1,4 +1,3 @@
-import { Card } from 'react-bootstrap';
 import classNames from 'classnames';
 
 import { Book } from '@/types';
@@ -32,7 +31,7 @@ export function BookCategoryView({ book }: Props) {
                 <p>{book.summary}</p>
                 <a
                     href={book.amazonProductURL}
-                    className="btn btn-primary stretched-link"
+                    className="btn btn-primary"
                     target="_blank"
                 >
                     BUY


### PR DESCRIPTION
# Description 

 This fixes all the body and title not to be a link except the `buy` button.

# Screenshot

![check](https://github.com/ContrarianMBA/www.contrarian.mba/assets/7629076/9cc5e2e3-321b-410c-8503-386640bbe389)
