### PR TITLE
🐛 fix: Google Analytics Code

### DIFF
--- a/src/components/GoogleAnalytics.tsx
+++ b/src/components/GoogleAnalytics.tsx
@@ -15,7 +15,7 @@ export function GoogleAnalytics() {
 window.dataLayer = window.dataLayer || [];
 function gtag(){dataLayer.push(arguments);}
 gtag('js', new Date());
-gtag('config', ${GOOGLE_MEASUREMENT_ID}, {
+gtag('config', '${GOOGLE_MEASUREMENT_ID}', {
 page_path: window.location.pathname,
 });
 `,


### PR DESCRIPTION
Missing quotes was causing console errors for Google Analytics.