### PR TITLE
🩹 fix: scroll glitch on some pages

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -67,7 +67,7 @@ export default function RootLayout({ children }: Props) {
             <GoogleAnalytics />
             <body className="d-flex flex-column vh-100">
                 <Header />
-                <main className="flex-grow-1">{children}</main>
+                <main className="flex-grow-1 mb-5">{children}</main>
                 <Footer />
             </body>
         </html>

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import { Container, Navbar } from 'react-bootstrap';
 
+import { HEADER_SCROLL_THRESHOLD } from '@/constants';
 import { MobileNav } from './MobileNav';
 import { PrimaryNav } from './PrimaryNav';
 
@@ -10,9 +11,9 @@ export function Header() {
 
     const handleScroll = () => {
         setFixed((state) => {
-            if (!state && window.scrollY > 350) {
+            if (!state && window.scrollY > HEADER_SCROLL_THRESHOLD) {
                 return true;
-            } else if (state && window.scrollY <= 350) {
+            } else if (state && window.scrollY <= HEADER_SCROLL_THRESHOLD) {
                 return false;
             } else {
                 return state;

--- a/src/constants/ui.ts
+++ b/src/constants/ui.ts
@@ -2,3 +2,5 @@ import { ColorMode } from '@/types';
 
 export const DEFAULT_COLOR_MODE: ColorMode = 'light';
 export const COLOR_MODE_STORAGE_KEY = 'colorMode';
+
+export const HEADER_SCROLL_THRESHOLD = 250;


### PR DESCRIPTION
Fixed scroll glitch on pages with two row books.
It was causing because header was trying to be sticky to top. Page height was just in a place to cause this glitch.

![image](https://github.com/ContrarianMBA/www.contrarian.mba/assets/1487670/28d388f0-202d-4287-b0c7-4aefa8df1176)